### PR TITLE
resolved check graphs bug

### DIFF
--- a/s
+++ b/s
@@ -1,7 +1,0 @@
-3 4
-0
-$,id2,id,MAIN
-0 -1 NoSem,1 1 NoSem,1 2 NoSem,0 -1 NoSem
-5 -1 NoSem,0 -1 NoSem,0 -1 NoSem,0 -1 NoSem
-5 -1 NoSem,0 -1 NoSem,0 -1 NoSem,0 -1 NoSem
-

--- a/s
+++ b/s
@@ -1,0 +1,7 @@
+3 4
+0
+$,id2,id,MAIN
+0 -1 NoSem,1 1 NoSem,1 2 NoSem,0 -1 NoSem
+5 -1 NoSem,0 -1 NoSem,0 -1 NoSem,0 -1 NoSem
+5 -1 NoSem,0 -1 NoSem,0 -1 NoSem,0 -1 NoSem
+

--- a/src/main/java/ir/ac/sbu/parser/LLParserGenerator.java
+++ b/src/main/java/ir/ac/sbu/parser/LLParserGenerator.java
@@ -66,6 +66,8 @@ public class LLParserGenerator {
                 .filter(graphModel -> nullableNodes.contains(graphModel.getStart().getId()))
                 .map(GraphModel::getName)
                 .collect(Collectors.toSet());
+
+        getTableString(30); //for finaly checking for errors
     }
 
     private void checkEdges() throws TableException {


### PR DESCRIPTION
hi
there was a bug in the check graph option that it didn't show all errors. as Rouzbeh Paktinat mentioned in [this video](https://www.dropbox.com/s/43lt3ta9j0ls0ml/PGen1.mp4?dl=0) in `7:75`, we should create table of the graph to make sure it is OK, checking graph option isn't enough.

I noticed that  check graph option in controller part, use constructor of `LLParserGenerator` class, the code below in main controller class:
```java
    public void parserCheckGraphs(ActionEvent actionEvent) {
        parserRenumber(actionEvent);
        try {
            new LLParserGenerator(graphs);
            DialogUtility.showSuccessDialog("There is no problem!");
        } catch (TableException e) {
            DialogUtility.showErrorDialog(e.getMessages());
        }
    }
```
we expect that the constructor throw `TableException` if there are any errors. it actually do this for some errors. but few errors are only found while creating table in method `buildTable` in parser.
the `buildPrettyTable` method which find errors is implemented like this:
```java
    public void buildPrettyTable(File file) throws TableException {
        try (PrintWriter writer = new PrintWriter(file)) {
            String tableString = getTableString(30);
            writer.println(tableString);
        } catch (FileNotFoundException e) {
            DialogUtility.showErrorDialog("Unable to create table: " + e.getMessage());
        }
    }
```
as we can see, errors are found in private method: `getTableString(30)`, so it is enough to call this method in constructor for double checking.
in last line of `LLParserGenerator` constructor i added this line: `getTableString(30)` and now, it can handle all errors. 

please merge this :)
i use java 11+ so i commit in this branch, i haven't checked other branch .
thank you